### PR TITLE
chore: Lowercase Gemini schema types and update tests

### DIFF
--- a/src/main/java/com/recipe/shared/schema/GeminiSchemaBuilder.java
+++ b/src/main/java/com/recipe/shared/schema/GeminiSchemaBuilder.java
@@ -11,7 +11,8 @@ public class GeminiSchemaBuilder {
     private final Map<String, Object> schema = new LinkedHashMap<>();
 
     private GeminiSchemaBuilder(GeminiSchemaType type) {
-        schema.put("type", type.name());
+        // The Gemini API expects lowercase type names (string, integer, etc.) in JSON Schema
+        schema.put("type", type.name().toLowerCase());
     }
 
     public static GeminiSchemaBuilder string() {

--- a/src/test/java/com/recipe/shared/schema/RecipeSchemaTest.java
+++ b/src/test/java/com/recipe/shared/schema/RecipeSchemaTest.java
@@ -25,12 +25,12 @@ public class RecipeSchemaTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> servings = (Map<String, Object>) props.get("servings");
         Assertions.assertNotNull(servings, "servings property must exist");
-        Assertions.assertEquals("INTEGER", servings.get("type"), "servings should be an INTEGER type");
+        Assertions.assertEquals("integer", servings.get("type"), "servings should be an integer type");
 
         @SuppressWarnings("unchecked")
         Map<String, Object> prepTimeMinutes = (Map<String, Object>) props.get("prepTimeMinutes");
         Assertions.assertNotNull(prepTimeMinutes, "prepTimeMinutes property must exist");
-        Assertions.assertEquals("INTEGER", prepTimeMinutes.get("type"), "prepTimeMinutes should be an INTEGER type");
+        Assertions.assertEquals("integer", prepTimeMinutes.get("type"), "prepTimeMinutes should be an integer type");
 
         // Verify nested nutritional info types
         @SuppressWarnings("unchecked")
@@ -48,6 +48,6 @@ public class RecipeSchemaTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> calories = (Map<String, Object>) perServingProps.get("calories");
         Assertions.assertNotNull(calories, "calories should be present in perServing");
-        Assertions.assertEquals("NUMBER", calories.get("type"), "calories should be a NUMBER type");
+        Assertions.assertEquals("number", calories.get("type"), "calories should be a number type");
     }
 }


### PR DESCRIPTION
Lowercase type names emitted by the GeminiSchemaBuilder to match the Generative Language API conventions (string, integer, number, object, array, boolean). Updated unit tests to assert lowercase values. This ensures 'responseSchema' is valid and prevents 400 errors from Gemini.