### PR TITLE
chore(gemini-schema): lowercase types & add tests

### DIFF
--- a/src/main/java/com/recipe/shared/schema/GeminiSchemaBuilder.java
+++ b/src/main/java/com/recipe/shared/schema/GeminiSchemaBuilder.java
@@ -98,7 +98,8 @@ public class GeminiSchemaBuilder {
 
     public static Map<String, Object> simpleProperty(GeminiSchemaType type, String description) {
         Map<String, Object> prop = new LinkedHashMap<>();
-        prop.put("type", type.name());
+        // Ensure the JSON Schema type is emitted in lowercase to match Gemini API expectations
+        prop.put("type", type.name().toLowerCase());
         prop.put("description", description);
         return Collections.unmodifiableMap(prop);
     }

--- a/src/test/java/com/recipe/shared/schema/GeminiSchemaBuilderTest.java
+++ b/src/test/java/com/recipe/shared/schema/GeminiSchemaBuilderTest.java
@@ -1,0 +1,25 @@
+package com.recipe.shared.schema;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class GeminiSchemaBuilderTest {
+
+    @Test
+    public void simplePropertyShouldEmitLowercaseType() {
+        Map<String, Object> s1 = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.STRING, "a string");
+        Assertions.assertEquals("string", s1.get("type"));
+        Map<String, Object> n = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.NUMBER, "a number");
+        Assertions.assertEquals("number", n.get("type"));
+        Map<String, Object> i = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.INTEGER, "an integer");
+        Assertions.assertEquals("integer", i.get("type"));
+        Map<String, Object> b = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.BOOLEAN, "a boolean");
+        Assertions.assertEquals("boolean", b.get("type"));
+        Map<String, Object> arr = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.ARRAY, "an array");
+        Assertions.assertEquals("array", arr.get("type"));
+        Map<String, Object> obj = GeminiSchemaBuilder.simpleProperty(GeminiSchemaType.OBJECT, "an object");
+        Assertions.assertEquals("object", obj.get("type"));
+    }
+}


### PR DESCRIPTION
Emit lowercase JSON Schema type names (string, number, integer, object, array, boolean) for Gemini compatibility and add unit tests for the builder. This PR also ensures downstream services using the shared library see lowercase types. Tests added to validate behavior.