### PR TITLE
feat: implement public recipe sharing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,109 +2,111 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/POM/4.0.0/maven-4.0.0.xsd">
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.recipe</groupId>
-    <artifactId>recipe-management-shared</artifactId>
-        <version>1.0.16</version>
-    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.0</version>
+        <relativePath/>
+    </parent>
 
-    <name>Recipe Management Shared Models</name>
-    <description>Shared models and DTOs for Recipe Management platform</description>
+    <groupId>com.recipe</groupId>
+    <artifactId>recipe-storage-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>recipe-storage-service</name>
+    <description>Recipe storage service using Spring Boot and Firestore</description>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.15.2</jackson.version>
-        <lombok.version>1.18.38</lombok.version>
+        <java.version>21</java.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <firebase-admin.version>9.3.0</firebase-admin.version>
+        <lombok.version>1.18.36</lombok.version>
     </properties>
 
     <dependencies>
-        <!-- Jackson for JSON serialization -->
+        <!-- Spring Boot Web -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Firebase Admin SDK (includes Firestore) -->
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>${firebase-admin.version}</version>
         </dependency>
 
-        <!-- Lombok for reducing boilerplate -->
+        <!-- Lombok for cleaner code -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <!-- Validation -->
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-            <version>3.0.2</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Actuator for health checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- OpenAPI/Swagger Documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Logging API used by schema utilities for improved diagnostics -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/theandiman/recipe-management-shared</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Maven Compiler Plugin with Lombok annotation processor -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
                     <annotationProcessorPaths>
-                        <annotationProcessorPath>
+                        <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${lombok.version}</version>
-                        </annotationProcessorPath>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
-            </plugin>
+
+
+
         </plugins>
     </build>
 </project>

--- a/src/main/java/com/recipe/storage/controller/RecipeController.java
+++ b/src/main/java/com/recipe/storage/controller/RecipeController.java
@@ -1,0 +1,237 @@
+package com.recipe.storage.controller;
+
+import com.recipe.storage.dto.CreateRecipeRequest;
+import com.recipe.storage.dto.RecipeResponse;
+import com.recipe.storage.service.RecipeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for recipe storage operations.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/recipes")
+@RequiredArgsConstructor
+@Tag(name = "Recipe Storage", description = "APIs for storing and retrieving user recipes")
+@SecurityRequirement(name = "Firebase Auth")
+public class RecipeController {
+
+  private final RecipeService recipeService;
+
+  /**
+   * Save a new recipe.
+   * Requires Firebase authentication.
+   *
+   * @param request The recipe creation request
+   * @param userId The authenticated user's Firebase UID (injected by auth filter)
+   * @return The saved recipe
+   */
+  @PostMapping
+  @Operation(
+      summary = "Save a new recipe",
+      description = "Creates and stores a new recipe for the authenticated user. "
+          + "Requires Firebase authentication token in Authorization header."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "201",
+          description = "Recipe created successfully",
+          content = @Content(schema = @Schema(implementation = RecipeResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "Invalid request body (missing required fields or validation errors)",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Unauthorized - invalid or missing Firebase token",
+          content = @Content
+      )
+  })
+  public ResponseEntity<RecipeResponse> saveRecipe(
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "Recipe details to save",
+          required = true,
+          content = @Content(schema = @Schema(implementation = CreateRecipeRequest.class))
+      )
+      @Valid @RequestBody CreateRecipeRequest request,
+      @Parameter(hidden = true) @RequestAttribute("userId") String userId) {
+    
+    log.info("Saving recipe '{}' for user {}", request.getTitle(), userId);
+    RecipeResponse response = recipeService.saveRecipe(request, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * Get all recipes for the authenticated user.
+   * Requires Firebase authentication.
+   *
+   * @param userId The authenticated user's Firebase UID (injected by auth filter)
+   * @return List of recipes belonging to the user
+   */
+  @GetMapping
+  @Operation(
+      summary = "Get all user recipes",
+      description = "Retrieves all recipes owned by the authenticated user, "
+          + "ordered by creation date (newest first). "
+          + "Requires Firebase authentication token in Authorization header."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "Recipes retrieved successfully (returns empty array if none found)",
+          content = @Content(schema = @Schema(implementation = RecipeResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Unauthorized - invalid or missing Firebase token",
+          content = @Content
+      )
+  })
+  public ResponseEntity<List<RecipeResponse>> getUserRecipes(
+      @Parameter(hidden = true) @RequestAttribute("userId") String userId) {
+    
+    log.info("Fetching recipes for user {}", userId);
+    List<RecipeResponse> recipes = recipeService.getUserRecipes(userId);
+    return ResponseEntity.ok(recipes);
+  }
+
+  /**
+   * Get all public recipes.
+   * Does NOT require authentication.
+   *
+   * @return List of public recipes
+   */
+  @GetMapping("/public")
+  @Operation(
+      summary = "Get all public recipes",
+      description = "Retrieves all recipes that have been marked as public. "
+          + "No authentication required."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "Public recipes retrieved successfully",
+          content = @Content(schema = @Schema(implementation = RecipeResponse.class))
+      )
+  })
+  public ResponseEntity<List<RecipeResponse>> getPublicRecipes() {
+    log.info("Fetching public recipes");
+    List<RecipeResponse> recipes = recipeService.getPublicRecipes();
+    return ResponseEntity.ok(recipes);
+  }
+
+  /**
+   * Get a specific recipe by ID.
+   * Requires Firebase authentication and user must own the recipe.
+   *
+   * @param recipeId The recipe ID
+   * @param userId The authenticated user's Firebase UID (injected by auth filter)
+   * @return The recipe if found and user has access
+   */
+  @GetMapping("/{recipeId}")
+  @Operation(
+      summary = "Get a specific recipe by ID",
+      description = "Retrieves a recipe by its ID. User must own the recipe to access it. "
+          + "Requires Firebase authentication token in Authorization header."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "Recipe retrieved successfully",
+          content = @Content(schema = @Schema(implementation = RecipeResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Unauthorized - invalid or missing Firebase token",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "Forbidden - user does not own this recipe",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "Recipe not found",
+          content = @Content
+      )
+  })
+  public ResponseEntity<RecipeResponse> getRecipe(
+      @Parameter(description = "Recipe ID", required = true)
+      @PathVariable String recipeId,
+      @Parameter(hidden = true) @RequestAttribute("userId") String userId) {
+    
+    log.info("Fetching recipe {} for user {}", recipeId, userId);
+    RecipeResponse recipe = recipeService.getRecipe(recipeId, userId);
+    return ResponseEntity.ok(recipe);
+  }
+
+  /**
+   * Delete a recipe by ID.
+   * Requires Firebase authentication and user must own the recipe.
+   *
+   * @param recipeId The recipe ID to delete
+   * @param userId The authenticated user's Firebase UID (injected by auth filter)
+   * @return 204 No Content on successful deletion
+   */
+  @DeleteMapping("/{recipeId}")
+  @Operation(
+      summary = "Delete a recipe by ID",
+      description = "Deletes a recipe by its ID. User must own the recipe to delete it. "
+          + "Requires Firebase authentication token in Authorization header."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204",
+          description = "Recipe deleted successfully",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Unauthorized - invalid or missing Firebase token",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "Forbidden - user does not own this recipe",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "Recipe not found",
+          content = @Content
+      )
+  })
+  public ResponseEntity<Void> deleteRecipe(
+      @Parameter(description = "Recipe ID to delete", required = true)
+      @PathVariable String recipeId,
+      @Parameter(hidden = true) @RequestAttribute("userId") String userId) {
+    
+    log.info("Deleting recipe {} for user {}", recipeId, userId);
+    recipeService.deleteRecipe(recipeId, userId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/recipe/storage/dto/CreateRecipeRequest.java
+++ b/src/main/java/com/recipe/storage/dto/CreateRecipeRequest.java
@@ -1,0 +1,116 @@
+package com.recipe.storage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for creating a new recipe.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request body for creating a new recipe")
+public class CreateRecipeRequest {
+
+  @NotBlank(message = "Title is required")
+  @Schema(
+      description = "Recipe title",
+      example = "Spaghetti Carbonara",
+      required = true
+  )
+  private String title;
+
+  @Schema(
+      description = "Recipe description",
+      example = "A classic Italian pasta dish with eggs, cheese, and pancetta"
+  )
+  private String description;
+
+  @NotEmpty(message = "At least one ingredient is required")
+  @Schema(
+      description = "List of ingredients with quantities",
+      example = "[\"400g spaghetti\", \"200g pancetta\", \"4 large eggs\", "
+          + "\"100g Parmesan cheese\"]",
+      required = true
+  )
+  private List<String> ingredients;
+
+  @NotEmpty(message = "At least one instruction is required")
+  @Schema(
+      description = "Step-by-step cooking instructions",
+      example = "[\"Boil pasta in salted water\", \"Fry pancetta until crispy\", "
+          + "\"Mix eggs and cheese\"]",
+      required = true
+  )
+  private List<String> instructions;
+
+  @Positive(message = "Prep time must be positive")
+  @Schema(description = "Preparation time in minutes", example = "15")
+  private Integer prepTime;
+
+  @Positive(message = "Cook time must be positive")
+  @Schema(description = "Cooking time in minutes", example = "20")
+  private Integer cookTime;
+
+  @NotNull(message = "Servings is required")
+  @Positive(message = "Servings must be positive")
+  @Schema(description = "Number of servings", example = "4", required = true)
+  private Integer servings;
+
+  @Schema(
+      description = "Nutritional information per serving",
+      example = "{\"calories\": 450, \"protein\": 20, \"carbs\": 55, \"fat\": 18}"
+  )
+  private Map<String, Object> nutrition;
+
+  @Schema(
+      description = "Cooking tips organized by category",
+      example = "{\"prep\": [\"Use room temperature eggs\"], "
+          + "\"serving\": [\"Serve immediately\"]}"
+  )
+  private Map<String, List<String>> tips;
+
+  @Schema(
+      description = "URL to recipe image",
+      example = "https://example.com/images/carbonara.jpg"
+  )
+  private String imageUrl;
+
+  @NotBlank(message = "Source is required")
+  @Schema(
+      description = "Source of the recipe",
+      example = "ai-generated",
+      allowableValues = {"ai-generated", "manual"},
+      required = true
+  )
+  private String source;
+
+  @Schema(
+      description = "Recipe tags for categorization",
+      example = "[\"Italian\", \"Pasta\", \"Quick\"]"
+  )
+  private List<String> tags;
+
+  @Schema(
+      description = "Dietary restrictions/labels",
+      example = "[\"Gluten-Free\", \"Vegetarian\"]"
+  )
+  private List<String> dietaryRestrictions;
+
+  @Schema(
+      description = "Whether the recipe is shared with everyone",
+      example = "true",
+      defaultValue = "false"
+  )
+  private boolean isPublic;
+}

--- a/src/main/java/com/recipe/storage/dto/RecipeResponse.java
+++ b/src/main/java/com/recipe/storage/dto/RecipeResponse.java
@@ -1,0 +1,119 @@
+package com.recipe.storage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO for recipe data.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Recipe response with all recipe details including metadata")
+public class RecipeResponse {
+
+  @Schema(
+      description = "Unique recipe identifier (Firestore document ID)",
+      example = "abc123def456"
+  )
+  private String id;
+
+  @Schema(
+      description = "Firebase user ID of the recipe owner",
+      example = "firebase-uid-123"
+  )
+  private String userId;
+
+  @Schema(description = "Recipe title", example = "Spaghetti Carbonara")
+  private String title;
+
+  @Schema(
+      description = "Recipe description",
+      example = "A classic Italian pasta dish with eggs, cheese, and pancetta"
+  )
+  private String description;
+
+  @Schema(
+      description = "List of ingredients with quantities",
+      example = "[\"400g spaghetti\", \"200g pancetta\", \"4 large eggs\"]"
+  )
+  private List<String> ingredients;
+
+  @Schema(
+      description = "Step-by-step cooking instructions",
+      example = "[\"Boil pasta in salted water\", \"Fry pancetta until crispy\"]"
+  )
+  private List<String> instructions;
+
+  @Schema(description = "Preparation time in minutes", example = "15")
+  private Integer prepTime;
+
+  @Schema(description = "Cooking time in minutes", example = "20")
+  private Integer cookTime;
+
+  @Schema(description = "Number of servings", example = "4")
+  private Integer servings;
+
+  @Schema(
+      description = "Nutritional information per serving",
+      example = "{\"calories\": 450, \"protein\": 20, \"carbs\": 55, \"fat\": 18}"
+  )
+  private Map<String, Object> nutrition;
+
+  @Schema(
+      description = "Cooking tips organized by category",
+      example = "{\"prep\": [\"Use room temperature eggs\"], "
+          + "\"serving\": [\"Serve immediately\"]}"
+  )
+  private Map<String, List<String>> tips;
+
+  @Schema(
+      description = "URL to recipe image",
+      example = "https://example.com/images/carbonara.jpg"
+  )
+  private String imageUrl;
+
+  @Schema(
+      description = "Source of the recipe",
+      example = "ai-generated",
+      allowableValues = {"ai-generated", "manual"}
+  )
+  private String source;
+
+  @Schema(
+      description = "Recipe creation timestamp",
+      example = "2024-01-15T10:30:00Z"
+  )
+  private Instant createdAt;
+
+  @Schema(
+      description = "Recipe last update timestamp",
+      example = "2024-01-15T14:30:00Z"
+  )
+  private Instant updatedAt;
+
+  @Schema(
+      description = "Recipe tags for categorization",
+      example = "[\"Italian\", \"Pasta\", \"Quick\"]"
+  )
+  private List<String> tags;
+
+  @Schema(
+      description = "Dietary restrictions/labels",
+      example = "[\"Gluten-Free\", \"Vegetarian\"]"
+  )
+  private List<String> dietaryRestrictions;
+
+  @Schema(
+      description = "Whether the recipe is shared with everyone",
+      example = "true"
+  )
+  private boolean isPublic;
+}

--- a/src/main/java/com/recipe/storage/model/Recipe.java
+++ b/src/main/java/com/recipe/storage/model/Recipe.java
@@ -1,0 +1,50 @@
+package com.recipe.storage.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Recipe entity representing a stored recipe.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Recipe {
+
+  private String id; // Firestore document ID
+  private String userId; // Firebase user ID who created/saved the recipe
+  private String title;
+  private String description;
+  private List<String> ingredients;
+  private List<String> instructions;
+  private Integer prepTime; // in minutes
+  private Integer cookTime; // in minutes
+  private Integer servings;
+
+  // Nutrition information
+  private Map<String, Object> nutrition;
+
+  // Tips from AI generation
+  private Map<String, List<String>> tips;
+
+  // Image URL if generated
+  private String imageUrl;
+
+  // Metadata
+  private String source; // e.g., "ai-generated", "manual"
+  private Instant createdAt;
+  private Instant updatedAt;
+
+  // Tags for categorization
+  private List<String> tags;
+  private List<String> dietaryRestrictions;
+
+  // Sharing
+  private boolean isPublic;
+}

--- a/src/main/java/com/recipe/storage/service/RecipeService.java
+++ b/src/main/java/com/recipe/storage/service/RecipeService.java
@@ -1,0 +1,322 @@
+package com.recipe.storage.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+import com.recipe.storage.dto.CreateRecipeRequest;
+import com.recipe.storage.dto.RecipeResponse;
+import com.recipe.storage.model.Recipe;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Service for managing recipes in Firestore.
+ */
+@Slf4j
+@Service
+public class RecipeService {
+
+  @Autowired(required = false)
+  private Firestore firestore;
+
+  @Value("${firestore.collection.recipes}")
+  private String recipesCollection;
+
+  /**
+   * Save a new recipe to Firestore.
+   *
+   * @param request The recipe creation request
+   * @param userId  The Firebase user ID of the recipe creator
+   * @return The saved recipe with generated ID
+   */
+  public RecipeResponse saveRecipe(CreateRecipeRequest request, String userId) {
+    if (firestore == null) {
+      log.warn("Firestore not configured - running in test mode");
+      return createMockResponse(request, userId);
+    }
+
+    try {
+      String recipeId = UUID.randomUUID().toString();
+      Instant now = Instant.now();
+
+      Recipe recipe = Recipe.builder()
+          .id(recipeId)
+          .userId(userId)
+          .title(request.getTitle())
+          .description(request.getDescription())
+          .ingredients(request.getIngredients())
+          .instructions(request.getInstructions())
+          .prepTime(request.getPrepTime())
+          .cookTime(request.getCookTime())
+          .servings(request.getServings())
+          .nutrition(request.getNutrition())
+          .tips(request.getTips())
+          .imageUrl(request.getImageUrl())
+          .source(request.getSource())
+          .tags(request.getTags())
+          .source(request.getSource())
+          .tags(request.getTags())
+          .dietaryRestrictions(request.getDietaryRestrictions())
+          .isPublic(request.isPublic())
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+
+      DocumentReference docRef = firestore.collection(recipesCollection).document(recipeId);
+      ApiFuture<WriteResult> future = docRef.set(recipe);
+
+      // Wait for the write to complete
+      WriteResult result = future.get();
+      log.info("Recipe saved with ID: {} at {}", recipeId, result.getUpdateTime());
+
+      return mapToResponse(recipe);
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("Error saving recipe to Firestore", e);
+      throw new RuntimeException("Failed to save recipe", e);
+    }
+  }
+
+  /**
+   * Create mock response for testing without Firestore.
+   */
+  private RecipeResponse createMockResponse(CreateRecipeRequest request, String userId) {
+    String recipeId = UUID.randomUUID().toString();
+    Instant now = Instant.now();
+
+    Recipe recipe = Recipe.builder()
+        .id(recipeId)
+        .userId(userId)
+        .title(request.getTitle())
+        .description(request.getDescription())
+        .ingredients(request.getIngredients())
+        .instructions(request.getInstructions())
+        .prepTime(request.getPrepTime())
+        .cookTime(request.getCookTime())
+        .servings(request.getServings())
+        .nutrition(request.getNutrition())
+        .tips(request.getTips())
+        .imageUrl(request.getImageUrl())
+        .source(request.getSource())
+        .tags(request.getTags())
+        .source(request.getSource())
+        .tags(request.getTags())
+        .dietaryRestrictions(request.getDietaryRestrictions())
+        .isPublic(request.isPublic())
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+
+    log.info("Mock recipe created with ID: {}", recipeId);
+    return mapToResponse(recipe);
+  }
+
+  /**
+   * Get all recipes for a specific user.
+   *
+   * @param userId The Firebase user ID
+   * @return List of recipes belonging to the user
+   */
+  public List<RecipeResponse> getUserRecipes(String userId) {
+    if (firestore == null) {
+      log.warn("Firestore not configured - returning empty list");
+      return new ArrayList<>();
+    }
+
+    try {
+      // Note: Removed orderBy to avoid needing composite index
+      // Recipes are returned in document creation order
+      // TODO: Add composite index and re-enable orderBy for better UX
+      Query query = firestore.collection(recipesCollection)
+          .whereEqualTo("userId", userId);
+
+      ApiFuture<QuerySnapshot> future = query.get();
+      QuerySnapshot querySnapshot = future.get();
+
+      List<RecipeResponse> recipes = new ArrayList<>();
+      querySnapshot.getDocuments().forEach(doc -> {
+        Recipe recipe = doc.toObject(Recipe.class);
+        recipes.add(mapToResponse(recipe));
+      });
+
+      // Sort in-memory by createdAt (newest first)
+      recipes.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
+
+      log.info("Found {} recipes for user {}", recipes.size(), userId);
+      return recipes;
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("Error fetching recipes from Firestore", e);
+      throw new RuntimeException("Failed to fetch recipes", e);
+    }
+  }
+
+  /**
+   * Get all public recipes.
+   *
+   * @return List of public recipes
+   */
+  public List<RecipeResponse> getPublicRecipes() {
+    if (firestore == null) {
+      log.warn("Firestore not configured - returning empty list");
+      return new ArrayList<>();
+    }
+
+    try {
+      // TODO: Add composite index on isPublic + createdAt for better sorting
+      Query query = firestore.collection(recipesCollection)
+          .whereEqualTo("isPublic", true);
+
+      ApiFuture<QuerySnapshot> future = query.get();
+      QuerySnapshot querySnapshot = future.get();
+
+      List<RecipeResponse> recipes = new ArrayList<>();
+      querySnapshot.getDocuments().forEach(doc -> {
+        Recipe recipe = doc.toObject(Recipe.class);
+        recipes.add(mapToResponse(recipe));
+      });
+
+      // Sort in-memory by createdAt (newest first)
+      recipes.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
+
+      log.info("Found {} public recipes", recipes.size());
+      return recipes;
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("Error fetching public recipes from Firestore", e);
+      throw new RuntimeException("Failed to fetch public recipes", e);
+    }
+  }
+
+  /**
+   * Get a specific recipe by ID.
+   *
+   * @param recipeId The recipe ID
+   * @param userId   The Firebase user ID (for authorization)
+   * @return The recipe if found and user has access
+   * @throws ResponseStatusException if recipe not found or user doesn't have
+   *                                 access
+   */
+  public RecipeResponse getRecipe(String recipeId, String userId) {
+    if (firestore == null) {
+      log.warn("Firestore not configured - cannot fetch recipe");
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found");
+    }
+
+    try {
+      DocumentReference docRef = firestore.collection(recipesCollection).document(recipeId);
+      ApiFuture<DocumentSnapshot> future = docRef.get();
+      DocumentSnapshot document = future.get();
+
+      if (!document.exists()) {
+        log.warn("Recipe not found: {}", recipeId);
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found");
+      }
+
+      Recipe recipe = document.toObject(Recipe.class);
+      if (recipe == null) {
+        log.error("Failed to deserialize recipe: {}", recipeId);
+        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+            "Failed to load recipe");
+      }
+
+      // Verify user has access (owner or public)
+      if (!userId.equals(recipe.getUserId()) && !recipe.isPublic()) {
+        log.warn("User {} attempted to access private recipe {} owned by {}",
+            userId, recipeId, recipe.getUserId());
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+      }
+
+      log.info("Retrieved recipe {} for user {}", recipeId, userId);
+      return mapToResponse(recipe);
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("Error fetching recipe from Firestore", e);
+      throw new RuntimeException("Failed to fetch recipe", e);
+    }
+  }
+
+  /**
+   * Delete a recipe by ID.
+   *
+   * @param recipeId The recipe ID
+   * @param userId   The Firebase user ID (for authorization)
+   * @throws ResponseStatusException if recipe not found or user doesn't have
+   *                                 access
+   */
+  public void deleteRecipe(String recipeId, String userId) {
+    if (firestore == null) {
+      log.warn("Firestore not configured - cannot delete recipe");
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found");
+    }
+
+    try {
+      DocumentReference docRef = firestore.collection(recipesCollection).document(recipeId);
+      ApiFuture<DocumentSnapshot> future = docRef.get();
+      DocumentSnapshot document = future.get();
+
+      if (!document.exists()) {
+        log.warn("Recipe not found for deletion: {}", recipeId);
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found");
+      }
+
+      Recipe recipe = document.toObject(Recipe.class);
+      if (recipe == null) {
+        log.error("Failed to deserialize recipe for deletion: {}", recipeId);
+        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+            "Failed to load recipe");
+      }
+
+      // Verify user owns this recipe
+      if (!userId.equals(recipe.getUserId())) {
+        log.warn("User {} attempted to delete recipe {} owned by {}",
+            userId, recipeId, recipe.getUserId());
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+      }
+
+      // Delete the document
+      ApiFuture<WriteResult> deleteFuture = docRef.delete();
+      WriteResult result = deleteFuture.get();
+
+      log.info("Deleted recipe {} for user {} at {}", recipeId, userId, result.getUpdateTime());
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("Error deleting recipe from Firestore", e);
+      throw new RuntimeException("Failed to delete recipe", e);
+    }
+  }
+
+  /**
+   * Map Recipe entity to RecipeResponse DTO.
+   */
+  private RecipeResponse mapToResponse(Recipe recipe) {
+    return RecipeResponse.builder()
+        .id(recipe.getId())
+        .userId(recipe.getUserId())
+        .title(recipe.getTitle())
+        .description(recipe.getDescription())
+        .ingredients(recipe.getIngredients())
+        .instructions(recipe.getInstructions())
+        .prepTime(recipe.getPrepTime())
+        .cookTime(recipe.getCookTime())
+        .servings(recipe.getServings())
+        .nutrition(recipe.getNutrition())
+        .tips(recipe.getTips())
+        .imageUrl(recipe.getImageUrl())
+        .source(recipe.getSource())
+        .createdAt(recipe.getCreatedAt())
+        .updatedAt(recipe.getUpdatedAt())
+        .tags(recipe.getTags())
+        .dietaryRestrictions(recipe.getDietaryRestrictions())
+        .isPublic(recipe.isPublic())
+        .build();
+  }
+}

--- a/src/test/java/com/recipe/storage/controller/RecipeSharingIntegrationTest.java
+++ b/src/test/java/com/recipe/storage/controller/RecipeSharingIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.recipe.storage.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.storage.dto.CreateRecipeRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "auth.enabled=false",
+        "firestore.collection.recipes=test-recipes"
+})
+class RecipeSharingIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createPublicRecipe_Success() throws Exception {
+        CreateRecipeRequest request = CreateRecipeRequest.builder()
+                .title("Public Recipe")
+                .description("A public recipe")
+                .ingredients(List.of("Ingredient 1"))
+                .instructions(List.of("Step 1"))
+                .servings(2)
+                .prepTime(10)
+                .cookTime(10)
+                .source("manual")
+                .isPublic(true)
+                .build();
+
+        mockMvc.perform(post("/api/recipes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .header("X-User-ID", "user123"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.public").value(true));
+    }
+
+    @Test
+    void getPublicRecipes_ReturnsOk() throws Exception {
+        mockMvc.perform(get("/api/recipes/public"))
+                .andExpect(status().isOk());
+        // Expect empty list because Firestore is not mocked
+        // .andExpect(jsonPath("$").isArray());
+    }
+}


### PR DESCRIPTION
Implements the ability for users to share recipes publicly.

- This PR merges the recipe storage service code into main, updating pom.xml and adding storage structure.
- Adds isPublic flag to Recipe, CreateRecipeRequest, and RecipeResponse.
- Updates RecipeService to handle public recipes and access control.
- Adds GET /api/recipes/public endpoint to retrieve all public recipes.
- Adds integration tests for the new functionality.