### PR TITLE
Fix isPublic field serialization for Firestore

### DIFF
--- a/src/main/java/com/recipe/shared/model/Recipe.java
+++ b/src/main/java/com/recipe/shared/model/Recipe.java
@@ -66,6 +66,7 @@ public class Recipe {
     private List<String> tags;
     private List<String> dietaryRestrictions;
 
+    @JsonProperty("isPublic")
     private boolean isPublic; // Whether recipe is publicly visible to other users
 
     // AI-specific fields (optional, for AI service compatibility)


### PR DESCRIPTION
## Problem
Recipe sharing status (isPublic) wasn't persisting properly. Field was being saved to Firestore but not read back correctly.

## Root Cause
Lombok generates `isPublic()` getter and `setPublic()` setter for boolean fields starting with "is". When Firestore deserializes with `toObject(Recipe.class)`, it looks for setter methods and might expect a field named "public" instead of "isPublic".

## Solution
Added `@JsonProperty("isPublic")` annotation to explicitly tell Firestore/Jackson to use "isPublic" as the field name for both serialization and deserialization.

## Verification
User confirmed that isPublic field IS being saved to Firestore correctly, so the issue was only with deserialization.

## Related
- Storage service PR with debug logging: #92
- Frontend sharing UI PR: theandiman/recipe-management-frontend#209