### PR TITLE
Fix: Add Firestore @PropertyName annotation for isPublic field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,14 @@
             <version>3.0.2</version>
         </dependency>
 
+        <!-- Firestore annotations for proper field mapping -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-firestore</artifactId>
+            <version>3.26.4</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/recipe/shared/model/Recipe.java
+++ b/src/main/java/com/recipe/shared/model/Recipe.java
@@ -2,6 +2,7 @@ package com.recipe.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.cloud.firestore.annotation.PropertyName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -66,7 +67,8 @@ public class Recipe {
     private List<String> tags;
     private List<String> dietaryRestrictions;
 
-    @JsonProperty("isPublic")
+    @JsonProperty("isPublic")  // For Jackson (REST API responses)
+    @PropertyName("isPublic")   // For Firestore serialization/deserialization
     private boolean isPublic; // Whether recipe is publicly visible to other users
 
     // AI-specific fields (optional, for AI service compatibility)


### PR DESCRIPTION
## Problem
Recipe sharing persistence still not working after adding @JsonProperty annotation.

## Root Cause
Firestore Admin SDK doesn't use Jackson for serialization - it uses its own mechanism with @PropertyName annotations. The @JsonProperty annotation only affects REST API responses, not Firestore document mapping.

When Firestore calls `document.toObject(Recipe.class)`, it looks for @PropertyName annotations, not @JsonProperty.

## Solution
- Added `google-cloud-firestore` dependency (scope: provided, since storage service already has it)
- Added `@PropertyName("isPublic")` annotation alongside existing `@JsonProperty`
- Both annotations are now present to handle both use cases:
  - @JsonProperty for REST API JSON serialization (Jackson)
  - @PropertyName for Firestore document serialization

## Testing
After deployment, the isPublic field should properly deserialize from Firestore documents and persist across page refreshes.

## Related
- Previous attempt with JsonProperty only: #37
- Storage service debug PR: theandiman/recipe-management-storage-service#92