### PR TITLE
Fix: Rename isPublic field to publicRecipe to resolve Lombok/Firestore conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.recipe</groupId>
     <artifactId>recipe-management-shared</artifactId>
-        <version>1.0.18</version>
+        <version>1.0.19</version>
     <packaging>jar</packaging>
 
     <name>Recipe Management Shared Models</name>

--- a/src/main/java/com/recipe/shared/model/Recipe.java
+++ b/src/main/java/com/recipe/shared/model/Recipe.java
@@ -67,9 +67,9 @@ public class Recipe {
     private List<String> tags;
     private List<String> dietaryRestrictions;
 
-    @JsonProperty("isPublic")  // For Jackson (REST API responses)
-    @PropertyName("isPublic")   // For Firestore serialization/deserialization
-    private boolean isPublic; // Whether recipe is publicly visible to other users
+    @JsonProperty("isPublic")  // For Jackson (REST API responses) - maintains API compatibility
+    @PropertyName("isPublic")   // For Firestore field name
+    private boolean publicRecipe; // Whether recipe is publicly visible to other users (renamed from isPublic to avoid Lombok getter/setter conflicts)
 
     // AI-specific fields (optional, for AI service compatibility)
     private Map<String, Object> imageGeneration; // AI image generation metadata

--- a/src/test/java/com/recipe/shared/model/RecipeTest.java
+++ b/src/test/java/com/recipe/shared/model/RecipeTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,7 +34,7 @@ class RecipeTest {
                 .source("manual")
                 .createdAt(Instant.parse("2024-01-01T10:00:00Z"))
                 .tags(Arrays.asList("breakfast", "easy"))
-                .isPublic(true)
+                .publicRecipe(true)
                 .build();
 
         // When
@@ -53,7 +52,7 @@ class RecipeTest {
         assertEquals(recipe.getServings(), deserialized.getServings());
         assertEquals(recipe.getSource(), deserialized.getSource());
         assertEquals(recipe.getTags(), deserialized.getTags());
-        assertEquals(recipe.isPublic(), deserialized.isPublic());
+        assertEquals(recipe.isPublicRecipe(), deserialized.isPublicRecipe());
     }
 
     @Test


### PR DESCRIPTION
## Problem
The `isPublic` boolean field wasn't being correctly deserialized from Firestore despite having the `@PropertyName("isPublic")` annotation.

**Root Cause:**
- Lombok generates `isPublic()` getter and `setPublic()` setter for a boolean field named `isPublic`
- Firestore's `@PropertyName` annotation doesn't work correctly with this Lombok-generated pattern
- Firestore expects standard JavaBean naming (getIsPublic/setIsPublic or getPublic/setPublic)

## Solution
Renamed the field from `isPublic` to `publicRecipe`:
- Lombok now generates `isPublicRecipe()` and `setPublicRecipe()` 
- Kept `@JsonProperty("isPublic")` for REST API backward compatibility
- Kept `@PropertyName("isPublic")` for Firestore field name mapping
- This allows proper Firestore deserialization while maintaining API compatibility

## Changes
- Renamed field: `isPublic` → `publicRecipe`
- Updated test assertions to use new getter method
- Bumped version to 1.0.19

## Impact
- **Storage service** will need to update to use `isPublicRecipe()` instead of `isPublic()`
- Frontend and REST API are unaffected (still uses "isPublic" in JSON)
- Firestore field name remains "isPublic"